### PR TITLE
aws_kms_key.log_key.id => aws_kms_key.log_key.arn

### DIFF
--- a/modules/network_firewall/main.tf
+++ b/modules/network_firewall/main.tf
@@ -60,7 +60,7 @@ data "aws_iam_policy_document" "policy_kms_logs_document" {
 # Create a Cloudwatch Log Group for AWS Network Firewall Alerts
 resource "aws_cloudwatch_log_group" "network_firewall_alert_log_group" {
   name = "/aws/network-firewall/alerts"
-  kms_key_id = aws_kms_key.log_key.id
+  kms_key_id = aws_kms_key.log_key.arn
   retention_in_days = 7
   tags = {
     Name = "network-firewall-alerts"


### PR DESCRIPTION


This PR should fix the issue which happens with the AWS provider 4.12.1:

```
 Error: Creating CloudWatch Log Group failed: InvalidParameterException: The specified KMS Key Id could not be found. '/aws/network-firewall/alerts'
│
│  with module.aws_network_firewall.aws_cloudwatch_log_group.network_firewall_alert_log_group,
│  on modules/network_firewall/main.tf line 61, in resource "aws_cloudwatch_log_group" "network_firewall_alert_log_group":
│  61: resource "aws_cloudwatch_log_group" "network_firewall_alert_log_group" {
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
