### PR TITLE
Fix local file contents (private key in PEM format)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -27,7 +27,7 @@ module "key_pair" {
 
 # Save the AWS SSH keypair to a local file
 resource "local_file" "private_key" {
-  content         = tls_private_key.private_key.public_key_openssh
+  content         = tls_private_key.private_key.private_key_pem
   filename        = "./keys/${module.key_pair.key_pair_key_name}.pem"
   file_permission = "0600"
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix: The private portion of the SSH key pair is now saved to the local file in PEM format. Before this PR, the public portion of the pair in OpenSSH format was saved to the local file with a `.pem` extension.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
