### PR TITLE
Add enabling Organization support for RAM to prerequisites

### DIFF
--- a/multi-account/README.md
+++ b/multi-account/README.md
@@ -8,6 +8,7 @@ This repository contains terraform code to deploy a sample AWS Hub and Spoke arc
 * Amazon VPC IPAM should be enabled in the AWS Organization
     * The *Networking Account* should be configured as the delegated Account to manage VPC IPAM.
     * Check the [VPC IPAM documentation](https://docs.aws.amazon.com/vpc/latest/ipam/enable-integ-ipam.html) for more information about the required configuration.
+* AWS Resource Access Manager has [resource sharing within AWS Organization enabled](https://docs.aws.amazon.com/ram/latest/userguide/getting-started-sharing.html#getting-started-sharing-orgs).
 * Terraform installed
 
 ## Code Principles:


### PR DESCRIPTION
Without enabling sharing within Organization enabled for RAM, running `terraform apply` in the security account (step 1) fails with a permission error. Enabling the option fixes the issue.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
